### PR TITLE
Add ability to use a previous deploy of Vercel if available for a particular SHA

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Do you have other Github actions (Lighthouse, Cypress, etc) that depend on the Vercel Preview URL? This action will wait until the url is available before running the next task.
 
-Please note that this action is supposed to be run on the `pull_request` event. 
+Please note that this action is supposed to be run on the `pull_request` event.
 
 ## Inputs
 
@@ -17,6 +17,10 @@ Optional — The name of the environment that was deployed to (e.g., staging or 
 ### `max_timeout`
 
 Optional — The amount of time to spend waiting on Vercel. Defaults to `60` seconds
+
+### `allow_inactive`
+
+Optional - Check for the most recent inactive deployment (previously deployed preview) associated with the pull request. Defaults to `false`.
 
 ## Outputs
 
@@ -37,6 +41,6 @@ steps:
       token: ${{ secrets.GITHUB_TOKEN }}
       max_timeout: 60
   # access preview url
-  - run: echo ${{steps.waitFor200.outputs.url}}  
-   
+  - run: echo ${{steps.waitFor200.outputs.url}}
+
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Optional — The amount of time to spend waiting on Vercel. Defaults to `60` sec
 
 ### `allow_inactive`
 
-Optional - Check for the most recent inactive deployment (previously deployed preview) associated with the pull request. Defaults to `false`.
+Optional - Use the most recent inactive deployment (previously deployed preview) associated with the pull request if
+ no new deployment is available. Defaults to `false`.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   environment:
     description: "The name of the environment that was deployed to (e.g., staging or production)"
     required: false
+  allow_inactive:
+    description: "Also check for most recent inactive deployment (previously deployed preview) associated with the pull request"
+    required: false
 outputs:
   url:
     description: "The fully qualified deploy preview URL"

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: "The name of the environment that was deployed to (e.g., staging or production)"
     required: false
   allow_inactive:
-    description: "Also check for most recent inactive deployment (previously deployed preview) associated with the pull request"
+    description: "Check for the most recent inactive deployment (previously deployed preview) associated with the pull request"
     required: false
 outputs:
   url:

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: "The name of the environment that was deployed to (e.g., staging or production)"
     required: false
   allow_inactive:
-    description: "Check for the most recent inactive deployment (previously deployed preview) associated with the pull request"
+    description: "Use the most recent inactive deployment (previously deployed preview) associated with the pull request if no new deployment is available."
     required: false
 outputs:
   url:


### PR DESCRIPTION
This changes adds a new input option to allow the action to fallback to an inactive deployment URL if one is available for the particular SHA within the PR. 

Currently, the action will poll the deployments associated with a PR to determine the Vercel URL associated with the SHA in the PR. For new deployments this works as expected. However if a new change is made to the PR that doesn't trigger a new Vercel deploy the action will fail because it is looking for a deployment with the status of "success". 

According to the [Vercel documentation](https://vercel.com/docs/platform/projects#ignored-build-step):
```
If the SHA of the commit was already deployed in the past, however, no new Deployment is created. In that case, the last Deployment matching that SHA is returned instead.
```

With the `allow_inactive` option users will able to use the action for both new and existing deployments.  An example of this input can be seen on https://github.com/hashicorp/packer/pull/10501