### PR TITLE
Add improved polling and allow finer-grained polling configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,15 @@ Optional — The name of the environment that was deployed to (e.g., staging or 
 
 ### `max_timeout`
 
-Optional — The amount of time to spend waiting on Vercel. Defaults to `60` seconds
+Optional — The amount of time  in seconds to spend waiting for this action to complete. When this time runs out, the action is automatically failed. It is strongly recommended that this is set to 3x the average deployment time. Defaults to `60` seconds.
+
+### `vercel_polling_interval`
+
+Optional — The polling period for Vercel's preview link. Defaults to `20` seconds.
+
+### `github_polling_interval`
+
+Optional — The polling period for checking on deployments and deployment status from Github. It is strongly recommended that this is set to ~ 1/10th of the average deployment time. Defaults to `20` seconds.
 
 ### `allow_inactive`
 

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,13 @@ inputs:
     description: "The Github Secret"
     required: true
   max_timeout:
-    description: "The max time to run the action"
+    description: "The max time (in seconds) to run the action"
+    required: false
+  vercel_polling_interval:
+    description: "How long (in seconds) we wait before polling the Vercel preview link again"
+    required: false
+  github_polling_interval:
+    description: "How long (in seconds) we wait before polling Github again"
     required: false
   environment:
     description: "The name of the environment that was deployed to (e.g., staging or production)"

--- a/index.js
+++ b/index.js
@@ -1,134 +1,130 @@
-const core = require("@actions/core");
-const github = require("@actions/github");
+const core = require('@actions/core');
+const github = require('@actions/github');
 const axios = require('axios');
 
-const waitForUrl = async (url, MAX_TIMEOUT) => {
-    const iterations = MAX_TIMEOUT / 2;
-    for (let i = 0; i < iterations; i++) {
-        try {
-            await axios.get(url);
-            return;
-        } catch (e) {
-            console.log("Url unavailable, retrying...");
-            await new Promise(r => setTimeout(r, 2000));
-        }
-    }
-    core.setFailed(`Timeout reached: Unable to connect to ${url}`);
+const sleepFor = ms => new Promise(r => setTimeout(r, ms));
+
+// This flag allows us to avoid making requests after the action has been killed.
+let isCanceled = false;
+// Promise.race "works", but is limited due to the pending event loop.
+// Using Promise.race, the event loop will not be empty and the action will succeed but at the max_timeout_ms.
+// See: https://github.com/nodejs/node/issues/37683
+const throwAfter = (fn, timeoutMs) =>
+  new Promise((res, rej) => {
+    const msg = `Maximum timeout of ${timeoutMs}ms has been reached, action has been cancelled.`;
+    const timeout = setTimeout(() => rej(new Error(msg)), timeoutMs);
+    fn()
+      .then((...args) => {
+        clearTimeout(timeout);
+        res(...args);
+      })
+      .catch(rej);
+  });
+const poll = async (fn, delayMs, times = 1) => {
+  console.log(`Polling attempted ${times} time(s).`);
+  // Do not poll for anything if the entire action was killed.
+  if (isCanceled) throw new Error('Job was cancelled, aborting.');
+  let result;
+  try {
+    result = await fn();
+  } catch (e) {
+    console.log(`Polling error`, e);
+  }
+  if (result) return result;
+  await sleepFor(delayMs);
+  return poll(fn, delayMs, times + 1);
 };
 
-const waitForStatus = async ({ token, owner, repo, deployment_id }, MAX_TIMEOUT, ALLOW_INACTIVE) => {
+const runAction = async ({ token, env, githubPollMs, vercelPollMs, allowInactive }) => {
+  const octokit = new github.getOctokit(token);
+  const context = github.context;
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+  const pullNumber = github.context.payload.pull_request.number;
+  if (!pullNumber) {
+    throw new Error('No pull request number was found');
+  }
+  const currentPR = await octokit.pulls.get({
+    owner,
+    repo,
+    pull_number: pullNumber,
+  });
+  if (currentPR.status !== 200) {
+    throw new Error('Could not get information about the current pull request');
+  }
+  const prSHA = currentPR.data.head.sha;
 
-    const octokit = new github.getOctokit(token);
-    const iterations = MAX_TIMEOUT / 2;
+  console.log(`Polling for deployments every ${githubPollMs}ms.`);
+  const deployment = await poll(async () => {
+    const deployments = await octokit.repos.listDeployments({
+      owner,
+      repo,
+      sha: prSHA,
+      environment: env,
+    });
+    const deployment = deployments.data && deployments.data[0];
+    console.log('deployment:');
+    console.log(JSON.stringify(deployment, null, 2));
+    return deployment;
+  }, githubPollMs);
 
-    for (let i = 0; i < iterations; i++) {
-        try {
-            const statuses = await octokit.repos.listDeploymentStatuses({
-                owner,
-                repo,
-                deployment_id
-            })
-
-            const status = statuses.data.length > 0 && statuses.data[0];
-
-            if ( !status ) {
-                throw Error('No status was available')
-            }
-
-            if ( status && ALLOW_INACTIVE === true && status.state === 'inactive') {
-              return status
-            }
-
-            if ( status && status.state !== 'success') {
-                throw Error('No status with state "success" was available')
-            }
-
-            if (status && status.state === 'success' ) {
-                return status
-            }
-
-            throw Error('Unknown status error')
-
-        } catch (e) {
-            console.log("Deployment unavailable or not successful, retrying...");
-            console.log(e)
-            await new Promise(r => setTimeout(r, 2000));
-        }
+  console.log(
+    `Polling for deployment status every ${githubPollMs}ms. Allowing Inactive deployments?: ${!!allowInactive}`,
+  );
+  const status = await poll(async () => {
+    const statuses = await octokit.repos.listDeploymentStatuses({
+      owner,
+      repo,
+      deployment_id: deployment.id,
+    });
+    console.log('deployment statuses');
+    console.log(JSON.stringify(statuses, null, 2));
+    const status = statuses.data.length > 0 && statuses.data[0];
+    if (!status) {
+      throw Error('No status was available');
     }
-    core.setFailed(`Timeout reached: Unable to wait for an deployment to be successful`);
-}
-
-const run = async () => {
-    try {
-
-        // Inputs
-        const GITHUB_TOKEN = core.getInput('token', { required: true })
-        const ENVIRONMENT = core.getInput('environment')
-        const MAX_TIMEOUT = Number(core.getInput("max_timeout")) || 60;
-        const ALLOW_INACTIVE = Boolean(core.getInput("allow_inactive")) || false;
-
-        // Fail if we have don't have a github token
-        if (!GITHUB_TOKEN) {
-            core.setFailed('Required field `token` was not provided')
-        }
-
-        const octokit = new github.getOctokit(GITHUB_TOKEN);
-
-        const context = github.context;
-        const owner = context.repo.owner
-        const repo = context.repo.repo
-        const PR_NUMBER = github.context.payload.pull_request.number
-
-        if (!PR_NUMBER) {
-            core.setFailed('No pull request number was found')
-        }
-
-        // Get information about the pull request
-        const currentPR = await octokit.pulls.get({
-            owner,
-            repo,
-            pull_number: PR_NUMBER
-        })
-
-        if (currentPR.status !== 200) {
-            core.setFailed('Could not get information about the current pull request')
-        }
-
-        // Get Ref from pull request
-        const prSHA = currentPR.data.head.sha
-
-        // Get deployments associated with the pull request
-        const deployments = await octokit.repos.listDeployments({
-            owner,
-            repo,
-            sha: prSHA,
-            environment: ENVIRONMENT
-        })
-
-        const deployment = deployments.data.length > 0 && deployments.data[0];
-
-        const status = await waitForStatus({
-            owner,
-            repo,
-            deployment_id: deployment.id,
-            token: GITHUB_TOKEN
-        }, MAX_TIMEOUT, ALLOW_INACTIVE)
-
-        // Get target url
-        const targetUrl = status.target_url
-
-        console.log('target url »', targetUrl)
-
-        // Set output
-        core.setOutput('url', targetUrl);
-
-        // Wait for url to respond with a sucess
-        console.log(`Waiting for a status code 200 from: ${targetUrl}`);
-        await waitForUrl(targetUrl, MAX_TIMEOUT);
-
-    } catch (error) {
-        core.setFailed(error.message);
+    if (allowInactive && status.state === 'inactive') {
+      return status;
     }
+    if (status.state === 'success') {
+      return status;
+    }
+    throw Error('No state with the allowed status was available');
+  }, githubPollMs);
+
+  // Get target url, set output, wait for url to respond w success
+  const targetUrl = status.target_url;
+  console.log(`Polling for vercel deployment at ${targetUrl} every ${vercelPollMs}ms.`);
+  core.setOutput('url', targetUrl);
+  await poll(async () => {
+    await axios.get(targetUrl);
+    return true;
+  }, vercelPollMs);
 };
 
-run();
+(async function main() {
+  try {
+    // In case Github actions does some weird caching.
+    isCanceled = false;
+    // Inputs
+    const token = core.getInput('token', { required: true });
+    const env = core.getInput('environment');
+    const timeoutMs = (Number(core.getInput('max_timeout')) || 60) * 1000;
+    const allowInactive = Boolean(core.getInput('allow_inactive')) || false;
+    const githubPollMs = (Number(core.getInput('github_polling_interval')) || 20) * 1000;
+    const vercelPollMs = (Number(core.getInput('github_polling_interval')) || 20) * 1000;
+    // Fail if we have don't have a github token
+    if (!token) {
+      throw new Error('Required field `token` was not provided');
+    }
+    await throwAfter(
+      () => runAction({ token, env, githubPollMs, vercelPollMs, allowInactive }),
+      timeoutMs,
+    );
+  } catch (err) {
+    // Avoid double cancellation
+    if (isCanceled) return;
+    isCanceled = true;
+    core.setFailed(err.message);
+  }
+})();


### PR DESCRIPTION
First off, thanks for writing this library/action!

We were using this Github action and ran into issues with the polling interval being too small (2s), causing us to spam our Github API and frequently run into rate-limits. Another edge case we ran into was that this action fails often if you push or force push a new commit to the PR branch, since the new deployment may not exist immediately. To fix this, we must also poll for deployments instead of firing off a one-off request. The math being done for the MAX_INTERVAL stuff was a bit off causing the action to not respect the MAX_TIMEOUT. I think a more reasonable approach is to kick off a timer and then fail the job when that timer resolves.

I've added a polling utility, `poll` and a fail-after-timeout utility `throwAfter` to help with these. This was deployed and tested in our own repo and seems to be working well. 

**I would strongly recommend that the polling intervals are set to ~1/10 of your average Vercel deploy build-time**, however I've tried to keep your defaults and naming for the sake of backwards compatibility.

Would appreciate a review! Thanks.