### PR TITLE
Fix version typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Basic Usage
 ```yaml
 steps:
   - name: Waiting for 200 from the Vercel Preview
-    uses: patrickedqvist/wait-for-vercel-preview@1.1.0
+    uses: patrickedqvist/wait-for-vercel-preview@v1.1.0
     id: waitFor200
     with:
       token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
For me `patrickedqvist/wait-for-vercel-preview@`1.1.0` does not work, `patrickedqvist/wait-for-vercel-preview@v1.1.0` does.