### PR TITLE
fix: use the full max_timeout for the deployment phase

### DIFF
--- a/action.js
+++ b/action.js
@@ -320,7 +320,7 @@ const run = async () => {
       sha: sha,
       environment: ENVIRONMENT,
       actorName: 'vercel[bot]',
-      maxTimeout: MAX_TIMEOUT / 2,
+      maxTimeout: MAX_TIMEOUT,
       checkIntervalInMilliseconds: CHECK_INTERVAL_IN_MS,
     });
 


### PR DESCRIPTION
A small change: currently the `waitForDeploymentToStart` step only uses half the available timeout time. For a long-running next.js build with 100's of pages, this time limit can easily be exceeded.

I'm not sure if something changed recently with how deployments are reported by the Vercel plugin, but I remember this step used to resolve very quickly.