### PR TITLE
Stop hiding error under the pretense of deployments

### DIFF
--- a/action.js
+++ b/action.js
@@ -228,15 +228,22 @@ const waitForDeploymentToStart = async ({
         return deployment;
       }
 
-      throw new Error(`no ${actorName} deployment found`);
-    } catch (e) {
       console.log(
         `Could not find any deployments for actor ${actorName}, retrying (attempt ${
           i + 1
         } / ${iterations})`
       );
-      await wait(checkIntervalInMilliseconds);
+    } catch(e) {
+      console.log(
+        `Error while fetching deployments, retrying (attempt ${
+          i + 1
+        } / ${iterations})`
+      );
+
+      console.error(e)
     }
+
+    await wait(checkIntervalInMilliseconds);
   }
 
   return null;


### PR DESCRIPTION
This code is hiding programming errors, and network errors under the
pretense that it could not find the deployment. I had to debug this
action manually and add logs here because it was potentially hiding
issues.

If you don't like that this code is duplicated, I can consolidate the
messaging but I don't think it's too bad.