### PR TITLE
Add `path` optional parameter to Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Optional - How often (in seconds) should we make the HTTP request checking to se
 
 Optional - The [password](https://vercel.com/docs/concepts/projects/overview#password-protection) for the deployment
 
+### `path`
+
+Optional - The URL that tests should run against (eg. `path: "https://vercel.com"`).
+
 ## Outputs
 
 ### `url`


### PR DESCRIPTION
I spent some time playing around with this action and realized that the code allows users to pass in a `path` parameter containing the URL which they wanted tests to run against but that parameter was not documented.

This PR adds documentation for the `path` optional parameter to the repo's Readme.