### PR TITLE
feat: adds support for x-vercel-protection-bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Optional - How often (in seconds) should we make the HTTP request checking to se
 
 Optional - The [password](https://vercel.com/docs/concepts/projects/overview#password-protection) for the deployment
 
+### `vercel_protection_bypass_header`
+
+Optional - The [header](https://vercel.com/docs/security/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation) to bypass protection for automation
+
 ### `path`
 
 Optional - The URL that tests should run against (eg. `path: "https://vercel.com"`).

--- a/action.js
+++ b/action.js
@@ -15,6 +15,7 @@ const waitForUrl = async ({
   maxTimeout,
   checkIntervalInMilliseconds,
   vercelPassword,
+  protectionBypassHeader,
   path,
 }) => {
   const iterations = calculateIterations(
@@ -37,6 +38,12 @@ const waitForUrl = async ({
         };
 
         core.setOutput('vercel_jwt', jwt);
+      }
+
+      if (protectionBypassHeader) {
+        headers = {
+          'x-vercel-protection-bypass': protectionBypassHeader
+        };
       }
 
       let checkUri = new URL(path, url);
@@ -280,6 +287,7 @@ const run = async () => {
     // Inputs
     const GITHUB_TOKEN = core.getInput('token', { required: true });
     const VERCEL_PASSWORD = core.getInput('vercel_password');
+    const VERCEL_PROTECTION_BYPASS_HEADER = core.getInput('vercel_protection_bypass_header');
     const ENVIRONMENT = core.getInput('environment');
     const MAX_TIMEOUT = Number(core.getInput('max_timeout')) || 60;
     const ALLOW_INACTIVE = Boolean(core.getInput('allow_inactive')) || false;
@@ -367,6 +375,7 @@ const run = async () => {
       maxTimeout: MAX_TIMEOUT,
       checkIntervalInMilliseconds: CHECK_INTERVAL_IN_MS,
       vercelPassword: VERCEL_PASSWORD,
+      protectionBypassHeader: VERCEL_PROTECTION_BYPASS_HEADER,
       path: PATH,
     });
   } catch (error) {

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
   vercel_password:
     description: 'Vercel password protection secret'
     required: false
+  vercel_protection_bypass_header:
+    description: 'Vercel protection bypass for automation'
+    required: false
   path:
     description: 'The path to check. Defaults to the index of the domain'
     default: '/'


### PR DESCRIPTION
## What:
The header is used to allow automation to bypass Vercel Authentication, Password Protection, and Trusted IPs
See [this Vercel doc](https://vercel.com/docs/security/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation) for more info.

## Why:
I'm currently using this to run my e2e playwright tests.
By merging this PR in others can use this feature too.

## Other:
If you have any questions or would like changes to this PR before merging please LMK
Finally this relates to issue #62, by using this header I was able to get a 200
Oh and it looks like this would close #55 