### PR TITLE
feat: add `project_filter` input to target specific Vercel deployments

### DIFF
--- a/action.js
+++ b/action.js
@@ -218,6 +218,7 @@ const waitForDeploymentToStart = async ({
     maxTimeout,
     checkIntervalInMilliseconds
   );
+  let lastMatchingDeployment = null;
 
   for (let i = 0; i < iterations; i++) {
     try {
@@ -228,8 +229,19 @@ const waitForDeploymentToStart = async ({
         environment,
       });
 
+      if (!deployments.data.length) {
+        console.log(`No deployments found for sha: ${sha}`);
+      }
+
       for (const deployment of deployments.data) {
-        if (deployment.creator.login !== actorName) continue;
+        console.log(`🔍 Checking deployment ID: ${deployment.id}`);
+
+        if (deployment.creator.login !== actorName) {
+          console.log(
+            `⏭️ Skipping deployment ID ${deployment.id} — actor mismatch`
+          );
+          continue;
+        }
 
         const status = await waitForStatus({
           token,
@@ -243,11 +255,16 @@ const waitForDeploymentToStart = async ({
 
         const targetUrl = status?.target_url;
 
-        if (!targetUrl) continue;
+        if (!targetUrl) {
+          console.log(
+            `⏭️ Skipping deployment ID ${deployment.id} — missing target_url`
+          );
+          continue;
+        }
 
         if (projectFilter && !targetUrl.includes(projectFilter)) {
           console.log(
-            `⏩ Skipping URL: ${targetUrl} (does not match project_filter "${projectFilter}")`
+            `⏭️ Skipping URL: ${targetUrl} (does not match project_filter "${projectFilter}")`
           );
           continue;
         }
@@ -257,8 +274,25 @@ const waitForDeploymentToStart = async ({
         return deployment;
       }
 
+      // Fallback: cache the last deployment matching actor + filter (even without status yet)
+      const fallbackDeployment = deployments.data.find((deployment) => {
+        const matchesActor = deployment.creator.login === actorName;
+        const matchesFilter =
+          !projectFilter ||
+          deployment.payload?.meta?.projectName?.includes(projectFilter) ||
+          false;
+        return matchesActor && matchesFilter;
+      });
+
+      if (fallbackDeployment) {
+        console.log(
+          `🕒 Caching fallback deployment ID: ${fallbackDeployment.id}`
+        );
+        lastMatchingDeployment = fallbackDeployment;
+      }
+
       console.log(
-        `Could not find any deployments for actor ${actorName}, retrying (attempt ${
+        `No matching deployments for actor ${actorName} and filter "${projectFilter}", retrying (attempt ${
           i + 1
         } / ${iterations})`
       );
@@ -268,16 +302,21 @@ const waitForDeploymentToStart = async ({
           i + 1
         } / ${iterations})`
       );
-
       console.error(e);
     }
 
     await wait(checkIntervalInMilliseconds);
   }
 
+  if (lastMatchingDeployment) {
+    console.log(
+      `⚠️ Timeout fallback — returning last matching deployment ID: ${lastMatchingDeployment.id}`
+    );
+    return lastMatchingDeployment;
+  }
+
   return null;
 };
-
 
 async function getShaForPullRequest({ octokit, owner, repo, number }) {
   const PR_NUMBER = github.context.payload.pull_request.number;

--- a/action.js
+++ b/action.js
@@ -146,6 +146,16 @@ const waitForStatus = async ({
 
       const status = statuses.data.length > 0 && statuses.data[0];
 
+      if (status) {
+        console.log(
+          `🟡 Deployment status found: state="${status.state}" (ID: ${deployment_id})`
+        );
+      } else {
+        console.log(
+          `⚠️ No deployment status found yet for deployment ID: ${deployment_id}`
+        );
+      }
+
       if (!status) {
         throw new StatusError('No status was available');
       }

--- a/action.js
+++ b/action.js
@@ -284,7 +284,6 @@ const waitForDeploymentToStart = async ({
         return deployment;
       }
 
-      // Fallback: cache the last deployment matching actor + filter (even without status yet)
       const fallbackDeployment = deployments.data.find((deployment) => {
         const matchesActor = deployment.creator.login === actorName;
         const matchesFilter =

--- a/action.yml
+++ b/action.yml
@@ -31,8 +31,9 @@ inputs:
     default: '/'
     required: false
   project_filter:
-    description: 'Optional filter for deployment project name or URL substring'
+    description: 'Optional. If set, will wait for the first deployment whose preview URL includes this string'
     required: false
+
 
 outputs:
   url:

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,9 @@ inputs:
     description: 'The path to check. Defaults to the index of the domain'
     default: '/'
     required: false
+  project_filter:
+    description: 'Optional filter for deployment project name or URL substring'
+    required: false
 
 outputs:
   url:

--- a/dist/index.js
+++ b/dist/index.js
@@ -290,7 +290,6 @@ const waitForDeploymentToStart = async ({
         return deployment;
       }
 
-      // Fallback: cache the last deployment matching actor + filter (even without status yet)
       const fallbackDeployment = deployments.data.find((deployment) => {
         const matchesActor = deployment.creator.login === actorName;
         const matchesFilter =

--- a/dist/index.js
+++ b/dist/index.js
@@ -48,7 +48,7 @@ const waitForUrl = async ({
 
       if (protectionBypassHeader) {
         headers = {
-          'x-vercel-protection-bypass': protectionBypassHeader
+          'x-vercel-protection-bypass': protectionBypassHeader,
         };
       }
 
@@ -216,6 +216,9 @@ const waitForDeploymentToStart = async ({
   actorName = 'vercel[bot]',
   maxTimeout = 20,
   checkIntervalInMilliseconds = 2000,
+  projectFilter,
+  token,
+  allowInactive,
 }) => {
   const iterations = calculateIterations(
     maxTimeout,
@@ -231,13 +234,32 @@ const waitForDeploymentToStart = async ({
         environment,
       });
 
-      const deployment =
-        deployments.data.length > 0 &&
-        deployments.data.find((deployment) => {
-          return deployment.creator.login === actorName;
+      for (const deployment of deployments.data) {
+        if (deployment.creator.login !== actorName) continue;
+
+        const status = await waitForStatus({
+          token,
+          owner,
+          repo,
+          deployment_id: deployment.id,
+          maxTimeout,
+          allowInactive,
+          checkIntervalInMilliseconds,
         });
 
-      if (deployment) {
+        const targetUrl = status?.target_url;
+
+        if (!targetUrl) continue;
+
+        if (projectFilter && !targetUrl.includes(projectFilter)) {
+          console.log(
+            `⏩ Skipping URL: ${targetUrl} (does not match project_filter "${projectFilter}")`
+          );
+          continue;
+        }
+
+        console.log(`✅ Selected deployment URL: ${targetUrl}`);
+        deployment._resolvedTargetUrl = targetUrl;
         return deployment;
       }
 
@@ -246,14 +268,14 @@ const waitForDeploymentToStart = async ({
           i + 1
         } / ${iterations})`
       );
-    } catch(e) {
+    } catch (e) {
       console.log(
         `Error while fetching deployments, retrying (attempt ${
           i + 1
         } / ${iterations})`
       );
 
-      console.error(e)
+      console.error(e);
     }
 
     await wait(checkIntervalInMilliseconds);
@@ -261,6 +283,7 @@ const waitForDeploymentToStart = async ({
 
   return null;
 };
+
 
 async function getShaForPullRequest({ octokit, owner, repo, number }) {
   const PR_NUMBER = github.context.payload.pull_request.number;
@@ -293,11 +316,14 @@ const run = async () => {
     // Inputs
     const GITHUB_TOKEN = core.getInput('token', { required: true });
     const VERCEL_PASSWORD = core.getInput('vercel_password');
-    const VERCEL_PROTECTION_BYPASS_HEADER = core.getInput('vercel_protection_bypass_header');
+    const VERCEL_PROTECTION_BYPASS_HEADER = core.getInput(
+      'vercel_protection_bypass_header'
+    );
     const ENVIRONMENT = core.getInput('environment');
     const MAX_TIMEOUT = Number(core.getInput('max_timeout')) || 60;
     const ALLOW_INACTIVE = Boolean(core.getInput('allow_inactive')) || false;
     const PATH = core.getInput('path') || '/';
+    const PROJECT_FILTER = core.getInput('project_filter');
     const CHECK_INTERVAL_IN_MS =
       (Number(core.getInput('check_interval')) || 2) * 1000;
 
@@ -338,11 +364,14 @@ const run = async () => {
       octokit,
       owner,
       repo,
-      sha: sha,
+      sha,
       environment: ENVIRONMENT,
       actorName: 'vercel[bot]',
       maxTimeout: MAX_TIMEOUT,
       checkIntervalInMilliseconds: CHECK_INTERVAL_IN_MS,
+      projectFilter: PROJECT_FILTER,
+      token: GITHUB_TOKEN,
+      allowInactive: ALLOW_INACTIVE,
     });
 
     if (!deployment) {
@@ -361,7 +390,7 @@ const run = async () => {
     });
 
     // Get target url
-    const targetUrl = status.target_url;
+    const targetUrl = deployment._resolvedTargetUrl || status.target_url;
 
     if (!targetUrl) {
       core.setFailed(`no target_url found in the status check`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -152,6 +152,16 @@ const waitForStatus = async ({
 
       const status = statuses.data.length > 0 && statuses.data[0];
 
+      if (status) {
+        console.log(
+          `🟡 Deployment status found: state="${status.state}" (ID: ${deployment_id})`
+        );
+      } else {
+        console.log(
+          `⚠️ No deployment status found yet for deployment ID: ${deployment_id}`
+        );
+      }
+
       if (!status) {
         throw new StatusError('No status was available');
       }


### PR DESCRIPTION
Adds a new `project_filter` input that allows users to wait for a specific Vercel deployment by matching a substring in the deployment's `target_url`.

This is useful in repos where multiple Vercel projects deploy in parallel, helping prevent false positives when downstream actions are reliant on the preview URL.

- Adds `project_filter` as an optional input  
- Matches deployments where the `target_url` includes the filter value  
- Skips deployments that don’t match
