### PR TITLE
Fix "allow_inactive" input treating the string "false" as true

### DIFF
--- a/action.js
+++ b/action.js
@@ -290,7 +290,7 @@ const run = async () => {
     const VERCEL_PROTECTION_BYPASS_HEADER = core.getInput('vercel_protection_bypass_header');
     const ENVIRONMENT = core.getInput('environment');
     const MAX_TIMEOUT = Number(core.getInput('max_timeout')) || 60;
-    const ALLOW_INACTIVE = Boolean(core.getInput('allow_inactive')) || false;
+    const ALLOW_INACTIVE = core.getBooleanInput('allow_inactive');
     const PATH = core.getInput('path') || '/';
     const CHECK_INTERVAL_IN_MS =
       (Number(core.getInput('check_interval')) || 2) * 1000;

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,7 @@ inputs:
   allow_inactive:
     description: 'Use the most recent inactive deployment (previously deployed preview) associated with the pull request if no new deployment is available.'
     required: false
+    default: 'false'
   check_interval:
     description: 'How often (in seconds) should we make the HTTP request checking to see if the deployment is available?'
     default: '2'

--- a/dist/index.js
+++ b/dist/index.js
@@ -296,7 +296,7 @@ const run = async () => {
     const VERCEL_PROTECTION_BYPASS_HEADER = core.getInput('vercel_protection_bypass_header');
     const ENVIRONMENT = core.getInput('environment');
     const MAX_TIMEOUT = Number(core.getInput('max_timeout')) || 60;
-    const ALLOW_INACTIVE = Boolean(core.getInput('allow_inactive')) || false;
+    const ALLOW_INACTIVE = core.getBooleanInput('allow_inactive');
     const PATH = core.getInput('path') || '/';
     const CHECK_INTERVAL_IN_MS =
       (Number(core.getInput('check_interval')) || 2) * 1000;

--- a/test/action.spec.js
+++ b/test/action.spec.js
@@ -11,6 +11,7 @@ jest.setTimeout(20000);
 jest.mock('@actions/core', () => {
   return {
     getInput: jest.fn(),
+    getBooleanInput: jest.fn(),
     setFailed: jest.fn(),
     setOutput: jest.fn(),
   };
@@ -410,23 +411,22 @@ describe('wait for vercel preview', () => {
  * @param {{
  *  token?: string,
  *  vercel_password?: string;
- *  allow_inactive?: boolean;
+ *  allow_inactive?: string;
  *  check_interval?: number;
  *  max_timeout?: number;
  *  path?: string;
  *  }} inputs
  */
 function setInputs(inputs = {}) {
-  const spy = jest.spyOn(core, 'getInput');
+  const spyGetInput = jest.spyOn(core, 'getInput');
+  const spyGetBooleanInput = jest.spyOn(core, 'getBooleanInput');
 
-  spy.mockImplementation((key) => {
+  spyGetInput.mockImplementation((key) => {
     switch (key) {
       case 'token':
         return inputs.token || '';
       case 'vercel_password':
         return inputs.vercel_password || '';
-      case 'allow_inactive':
-        return `${inputs.allow_inactive || ''}`;
       case 'check_interval':
         return `${inputs.check_interval || ''}`;
       case 'max_timeout':
@@ -435,6 +435,15 @@ function setInputs(inputs = {}) {
         return `${inputs.path || ''}`;
       default:
         return '';
+    }
+  });
+
+  spyGetBooleanInput.mockImplementation((key) => {
+    switch (key) {
+      case 'allow_inactive':
+        return String(inputs.allow_inactive).toLowerCase() === 'true';
+      default:
+        return false;
     }
   });
 }

--- a/test/action.spec.js
+++ b/test/action.spec.js
@@ -294,6 +294,115 @@ describe('wait for vercel preview', () => {
       'a-super-secret-jwt'
     );
   });
+
+  test('fails if allow_inactive is set to false but the only status is inactive', async () => {
+    setInputs({
+      token: 'a-token',
+      allow_inactive: 'false',
+      max_timeout: 5,
+      check_interval: 1,
+    });
+
+    setGithubContext({
+      payload: {
+        pull_request: {
+          number: 99,
+        },
+      },
+    });
+
+    ghResponse('/repos/gh-user/best-repo-ever/pulls/99', 200, {
+      head: {
+        sha: 'abcdef12345678',
+      },
+    });
+
+    ghResponse('/repos/gh-user/best-repo-ever/deployments', 200, [
+      {
+        id: 'fake-deployment-id',
+        creator: {
+          login: 'vercel[bot]',
+        },
+      },
+    ]);
+
+    ghResponse(
+        '/repos/gh-user/best-repo-ever/deployments/fake-deployment-id/statuses',
+        200,
+        [
+          {
+            state: 'inactive',
+            target_url: 'https://my-preview.vercel.app/',
+          },
+        ]
+    );
+
+    await run();
+
+    expect(core.setFailed).toHaveBeenCalledWith(
+        'Timeout reached: Unable to wait for an deployment to be successful'
+    );
+  });
+
+  test('succeeds if allow_inactive is set to true and the only status is inactive', async () => {
+    setInputs({
+      token: 'a-token',
+      allow_inactive: 'true',
+      max_timeout: 5,
+      check_interval: 1,
+    });
+
+    setGithubContext({
+      payload: {
+        pull_request: {
+          number: 99,
+        },
+      },
+    });
+
+    ghResponse('/repos/gh-user/best-repo-ever/pulls/99', 200, {
+      head: {
+        sha: 'abcdef12345678',
+      },
+    });
+
+    ghResponse('/repos/gh-user/best-repo-ever/deployments', 200, [
+      {
+        id: 'fake-deployment-id',
+        creator: {
+          login: 'vercel[bot]',
+        },
+      },
+    ]);
+
+    ghResponse(
+        '/repos/gh-user/best-repo-ever/deployments/fake-deployment-id/statuses',
+        200,
+        [
+          {
+            state: 'inactive',
+            target_url: 'https://my-preview.vercel.app/',
+          },
+        ]
+    );
+
+    restTimes('https://my-preview.vercel.app/', [
+      {
+        status: 200,
+        body: 'OK!',
+        times: 1,
+      },
+    ]);
+
+    await run();
+
+    expect(core.setFailed).not.toHaveBeenCalled();
+
+    expect(core.setOutput).toHaveBeenCalledWith(
+        'url',
+        'https://my-preview.vercel.app/'
+    );
+  });
 });
 
 /**
@@ -301,6 +410,7 @@ describe('wait for vercel preview', () => {
  * @param {{
  *  token?: string,
  *  vercel_password?: string;
+ *  allow_inactive?: boolean;
  *  check_interval?: number;
  *  max_timeout?: number;
  *  path?: string;
@@ -315,6 +425,8 @@ function setInputs(inputs = {}) {
         return inputs.token || '';
       case 'vercel_password':
         return inputs.vercel_password || '';
+      case 'allow_inactive':
+        return `${inputs.allow_inactive || ''}`;
       case 'check_interval':
         return `${inputs.check_interval || ''}`;
       case 'max_timeout':


### PR DESCRIPTION
The `allow_inactive` input is intended to default to false, but explicitly providing the string "false" (e.g. with `with: allow_inactive: false`) mistakenly enables it. This happens because `Boolean("false")` in JavaScript is truthy. This PR resolves the minor issue by using `core.getBooleanInput`, ensuring that "false" is correctly parsed as a boolean false, preserving the default behavior.