### PR TITLE
feat: add allow_unauthenticated input to treat 401 errors as success

### DIFF
--- a/action.js
+++ b/action.js
@@ -17,6 +17,7 @@ const waitForUrl = async ({
   vercelPassword,
   protectionBypassHeader,
   path,
+  allowUnauthenticated,
 }) => {
   const iterations = calculateIterations(
     maxTimeout,
@@ -59,6 +60,12 @@ const waitForUrl = async ({
         console.log(
           `GET status: ${e.response.status}. Attempt ${i} of ${iterations}`
         );
+        
+        // If allowUnauthenticated is true and we get a 401, treat it as success
+        if (allowUnauthenticated && e.response.status === 401) {
+          console.log('Received 401 status code, treating as success due to allow_unauthenticated setting');
+          return;
+        }
       } else if (e.request) {
         console.log(
           `GET error. A request was made, but no response was received. Attempt ${i} of ${iterations}`
@@ -291,6 +298,7 @@ const run = async () => {
     const ENVIRONMENT = core.getInput('environment');
     const MAX_TIMEOUT = Number(core.getInput('max_timeout')) || 60;
     const ALLOW_INACTIVE = core.getBooleanInput('allow_inactive');
+    const ALLOW_UNAUTHENTICATED = core.getBooleanInput('allow_unauthenticated');
     const PATH = core.getInput('path') || '/';
     const CHECK_INTERVAL_IN_MS =
       (Number(core.getInput('check_interval')) || 2) * 1000;
@@ -377,6 +385,7 @@ const run = async () => {
       vercelPassword: VERCEL_PASSWORD,
       protectionBypassHeader: VERCEL_PROTECTION_BYPASS_HEADER,
       path: PATH,
+      allowUnauthenticated: ALLOW_UNAUTHENTICATED,
     });
   } catch (error) {
     core.setFailed(error.message);

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: 'The path to check. Defaults to the index of the domain'
     default: '/'
     required: false
+  allow_unauthenticated:
+    description: 'Allow unauthenticated access (401 errors) to be treated as success. Useful when deployment is complete but authentication is not configured.'
+    default: 'false'
+    required: false
 
 outputs:
   url:

--- a/test/action.spec.js
+++ b/test/action.spec.js
@@ -404,6 +404,7 @@ describe('wait for vercel preview', () => {
         'https://my-preview.vercel.app/'
     );
   });
+
 });
 
 /**
@@ -412,6 +413,7 @@ describe('wait for vercel preview', () => {
  *  token?: string,
  *  vercel_password?: string;
  *  allow_inactive?: string;
+ *  allow_unauthenticated?: string;
  *  check_interval?: number;
  *  max_timeout?: number;
  *  path?: string;
@@ -442,6 +444,8 @@ function setInputs(inputs = {}) {
     switch (key) {
       case 'allow_inactive':
         return String(inputs.allow_inactive).toLowerCase() === 'true';
+      case 'allow_unauthenticated':
+        return String(inputs.allow_unauthenticated).toLowerCase() === 'true';
       default:
         return false;
     }


### PR DESCRIPTION
**Problem**
Some users experience 401 errors when Vercel deployments are complete but authentication is not properly configured. Currently, the action treats 401 errors as failures and continues retrying, which is unnecessary when the deployment is actually ready and accessible.

**Solution**
Added a new optional input parameter allow_unauthenticated that allows 401 errors to be treated as successful deployments. When enabled, the action will stop checking and return successfully upon encountering a 401 status code.

**Changes**
- Added allow_unauthenticated input parameter in action.yml (defaults to false)
- Modified waitForUrl function to handle 401 errors when allow_unauthenticated is true
- Updated main run function to read and pass the new parameter
- Updated test helper functions to support the new parameter

**Usage**
```
- uses: your-action@v1
  with:
    token: ${{ secrets.GITHUB_TOKEN }}
    allow_unauthenticated: true
```
**Benefits**
- Allows users to proceed when deployment is complete but auth isn't configured
- Reduces unnecessary retries and timeout failures
- Maintains backward compatibility (defaults to false)
- Clear, descriptive parameter name that explains the use case

This addresses the common scenario where users only care that their Vercel preview is deployed and accessible, regardless of authentication status.